### PR TITLE
feat(ci): add signing, CI workflow, and build fixes

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,68 @@
+name: Android CI/CD
+
+on:
+  push:
+    branches:
+      - main
+      - 'feature/**' # Triggers on feature branches
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      # CRITICAL FOR SDK 36: Accept licenses before building
+      - name: Accept Android SDK Licenses
+        run: |
+          yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses || true
+
+      - name: Decode Keystore
+        id: decode_keystore
+        uses: timheuer/base64-to-file@v1.2
+        with:
+          fileName: 'release.jks'
+          encodedString: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+
+      # Build the AAB
+      # We pass -PversionCode=${{ github.run_number }} to increment the version automatically
+      - name: Build Release Bundle
+        run: ./gradlew bundleRelease -PversionCode=${{ github.run_number }}
+        env:
+          KEYSTORE_FILE: ${{ steps.decode_keystore.outputs.filePath }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+
+      # Determine Track: Main -> Production, Others -> Internal (Closed)
+      - name: Determine Track
+        id: track
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "track_name=production" >> $GITHUB_OUTPUT
+            echo "status=draft" >> $GITHUB_OUTPUT
+            echo "Deployment target: PRODUCTION (Draft)"
+          else
+            echo "track_name=internal" >> $GITHUB_OUTPUT
+            echo "status=completed" >> $GITHUB_OUTPUT
+            echo "Deployment target: INTERNAL / CLOSED TESTING"
+          fi
+
+      - name: Upload to Play Store
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_CONFIG_JSON }}
+          packageName: tools.interviews.android
+          releaseFiles: app/build/outputs/bundle/release/app-release.aab
+          track: ${{ steps.track.outputs.track_name }}
+          status: ${{ steps.track.outputs.status }}
+          # Mappings for crash de-obfuscation
+          mappingFile: app/build/outputs/mapping/release/mapping.txt

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 .externalNativeBuild
 .cxx
 local.properties
+*.jks
+app/release

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.io.FileInputStream
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -11,11 +14,25 @@ android {
         version = release(36)
     }
 
+    signingConfigs {
+        create("release") {
+            // Logic: Checks Env vars (GitHub Actions).
+            // If missing, falls back to a dummy "keystore.jks" to prevent sync errors.
+            val keystorePath = System.getenv("KEYSTORE_FILE") ?: "keystore.jks"
+
+            // Fixed: Kotlin DSL requires '=' for assignments
+            storeFile = file(keystorePath)
+            storePassword = System.getenv("KEYSTORE_PASSWORD")
+            keyAlias = System.getenv("KEY_ALIAS")
+            keyPassword = System.getenv("KEY_PASSWORD")
+        }
+    }
+
     defaultConfig {
         applicationId = "tools.interviews.android"
         minSdk = 31
         targetSdk = 36
-        versionCode = 1
+        versionCode = project.findProperty("versionCode")?.toString()?.toIntOrNull() ?: 1
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -23,6 +40,7 @@ android {
 
     buildTypes {
         release {
+            signingConfig = signingConfigs.getByName("release")
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),


### PR DESCRIPTION
Add release signing config, CI workflow, and related build improvements
to enable automated bundle builds and Play Store uploads.

- app/build.gradle.kts
  - Add imports for Properties and FileInputStream to support env-based
    signing logic.
  - Create a release signingConfig that reads keystore path and
    credentials from environment variables, falling back to a dummy
    keystore to avoid IDE sync errors. Fix Kotlin DSL assignment
    (storeFile = file(...)).
  - Use project property for versionCode fallback so CI can pass
    -PversionCode to auto-increment builds.
  - Assign release buildType to the created signingConfig.

- .gitignore
  - Ignore keystore files and app/release outputs to avoid committing
    sensitive artifacts.

- .github/workflows/android.yml
  - Add GitHub Actions workflow to build and deploy AABs:
    - Checkout, set up JDK 17, accept SDK licenses.
    - Decode keystore from base64 secret and set env vars for Gradle.
    - Build release bundle with versionCode from github.run_number.
    - Determine release track (production for main, internal for others)
      and upload bundle to Play Store with mapping file for deobfuscation.

Reason:
Enable secure, automated CI/CD for release bundles while preventing
local sync failures and allowing automated versioning and deployment.