### PR TITLE
feat(next-stage): carry over and close previous interview on

### DIFF
--- a/.idea/appInsightsSettings.xml
+++ b/.idea/appInsightsSettings.xml
@@ -3,6 +3,20 @@
   <component name="AppInsightsSettings">
     <option name="tabSettings">
       <map>
+        <entry key="Android Vitals">
+          <value>
+            <InsightsFilterSettings>
+              <option name="connection">
+                <ConnectionSetting>
+                  <option name="appId" value="tools.interviews.android" />
+                </ConnectionSetting>
+              </option>
+              <option name="signal" value="SIGNAL_UNSPECIFIED" />
+              <option name="timeIntervalDays" value="SEVEN_DAYS" />
+              <option name="visibilityType" value="ALL" />
+            </InsightsFilterSettings>
+          </value>
+        </entry>
         <entry key="Firebase Crashlytics">
           <value>
             <InsightsFilterSettings>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-12-15T13:37:14.728963Z">
+        <DropdownSelection timestamp="2025-12-19T17:20:25.037912Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/keloran/.android/avd/Pixel_Fold.avd" />
+              <DeviceId pluginId="PhysicalDevice" identifier="serial=37291FDHS001HD" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,7 +33,7 @@ android {
         minSdk = 31
         targetSdk = 36
         versionCode = project.findProperty("versionCode")?.toString()?.toIntOrNull() ?: 1
-        versionName = "1.0"
+        versionName = "1.0.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/tools/interviews/android/MainActivity.kt
+++ b/app/src/main/java/tools/interviews/android/MainActivity.kt
@@ -258,6 +258,7 @@ class MainActivity : AppCompatActivity() {
     private fun launchNextStage(interview: Interview) {
         val intent = Intent(this, AddInterviewActivity::class.java).apply {
             putExtra(AddInterviewActivity.EXTRA_NEXT_STAGE_MODE, true)
+            putExtra(AddInterviewActivity.EXTRA_PREVIOUS_INTERVIEW_ID, interview.id)
             putExtra(AddInterviewActivity.EXTRA_COMPANY_NAME, interview.companyName)
             putExtra(AddInterviewActivity.EXTRA_CLIENT_COMPANY, interview.clientCompany)
             putExtra(AddInterviewActivity.EXTRA_JOB_TITLE, interview.jobTitle)


### PR DESCRIPTION
Add support for a "next stage" flow where a new interview is created
from an existing one and the previous interview is automatically marked
as PASSED after saving the new interview.

- Add EXTRA_PREVIOUS_INTERVIEW_ID constant and previousInterviewId
  field to AddInterviewActivity; read the ID when entering next-stage
  mode so the previous interview can be updated after save.
- On save, look up the previous interview, set outcome to PASSED and
  update it in the local repository. If the previous interview was
  synced (has serverId) and the user is signed in, attempt to update
  the remote interview as well. Add error handling and logging around
  these operations.
- Propagate the previous interview's id from MainActivity when
  launching AddInterviewActivity in next-stage mode.
- Bump app versionName to 1.0.1.
- Minor IDE metadata updates (deployment target and app insights
  settings).

These changes let users advance an interview to the next stage while
keeping the prior interview marked as completed/passed and keep remote
state consistent when possible.