### PR TITLE
feat(ui): add pull-to-refresh and refresh wiring

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,11 +4,16 @@ on:
   push:
     branches:
       - main
-      - 'feature/**' # Triggers on feature branches
+      - 'feature/**'
+    tags:
+      - 'v*'  # Triggers on version tags like v1.0.0
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
+    outputs:
+      should_deploy: ${{ steps.check_deploy.outputs.should_deploy }}
+      deploy_track: ${{ steps.check_deploy.outputs.deploy_track }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -33,7 +38,6 @@ jobs:
           encodedString: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
 
       # Build the AAB
-      # We pass -PversionCode=${{ github.run_number }} to increment the version automatically
       - name: Build Release Bundle
         run: ./gradlew bundleRelease -PversionCode=${{ github.run_number }}
         env:
@@ -42,27 +46,65 @@ jobs:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 
-      # Determine Track: Main -> Production, Others -> Internal (Closed)
-      - name: Determine Track
-        id: track
+      # Determine if we should deploy and to which track
+      - name: Check Deployment Target
+        id: check_deploy
         run: |
-          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "track_name=production" >> $GITHUB_OUTPUT
-            echo "status=draft" >> $GITHUB_OUTPUT
-            echo "Deployment target: PRODUCTION (Draft)"
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            echo "should_deploy=true" >> $GITHUB_OUTPUT
+            echo "deploy_track=production" >> $GITHUB_OUTPUT
+            echo "🚀 Tagged release - will deploy to PRODUCTION"
+          elif [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "should_deploy=true" >> $GITHUB_OUTPUT
+            echo "deploy_track=internal" >> $GITHUB_OUTPUT
+            echo "🧪 Main branch - will deploy to INTERNAL TESTING"
           else
-            echo "track_name=internal" >> $GITHUB_OUTPUT
-            echo "status=completed" >> $GITHUB_OUTPUT
-            echo "Deployment target: INTERNAL / CLOSED TESTING"
+            echo "should_deploy=false" >> $GITHUB_OUTPUT
+            echo "deploy_track=" >> $GITHUB_OUTPUT
+            echo "🔨 Feature branch - build only, no deployment"
           fi
+
+      # Upload AAB as artifact (useful for feature branches and debugging)
+      - name: Upload AAB Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release
+          path: app/build/outputs/bundle/release/app-release.aab
+          retention-days: 14
+
+      # Upload mapping file as artifact
+      - name: Upload Mapping File
+        uses: actions/upload-artifact@v4
+        if: hashFiles('app/build/outputs/mapping/release/mapping.txt') != ''
+        with:
+          name: mapping
+          path: app/build/outputs/mapping/release/mapping.txt
+          retention-days: 14
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    if: needs.build.outputs.should_deploy == 'true'
+    steps:
+      - name: Download AAB Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: app-release
+          path: ./release
+
+      - name: Download Mapping File
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: mapping
+          path: ./mapping
 
       - name: Upload to Play Store
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_CONFIG_JSON }}
           packageName: tools.interviews.android
-          releaseFiles: app/build/outputs/bundle/release/app-release.aab
-          track: ${{ steps.track.outputs.track_name }}
-          status: ${{ steps.track.outputs.status }}
-          # Mappings for crash de-obfuscation
-          mappingFile: app/build/outputs/mapping/release/mapping.txt
+          releaseFiles: ./release/app-release.aab
+          track: ${{ needs.build.outputs.deploy_track }}
+          status: completed
+          mappingFile: ./mapping/mapping.txt

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,6 +76,7 @@ dependencies {
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.recyclerview)
     implementation(libs.androidx.window)
+    implementation(libs.androidx.swiperefresh)
 
     // Room Database
     implementation(libs.androidx.room.runtime)

--- a/app/src/main/res/layout-sw600dp/activity_main.xml
+++ b/app/src/main/res/layout-sw600dp/activity_main.xml
@@ -175,59 +175,66 @@
                     android:layout_height="1dp"
                     android:background="?attr/colorOutlineVariant" />
 
-                <!-- Scrollable List Area -->
-                <FrameLayout
+                <!-- Scrollable List Area with Pull-to-Refresh -->
+                <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+                    android:id="@+id/swipeRefreshLayout"
                     android:layout_width="match_parent"
                     android:layout_height="0dp"
                     android:layout_weight="1">
 
-                    <!-- Interview List (scrolls independently) -->
-                    <androidx.recyclerview.widget.RecyclerView
-                        android:id="@+id/recyclerViewInterviews"
+                    <FrameLayout
                         android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:clipToPadding="false"
-                        android:paddingBottom="80dp" />
+                        android:layout_height="match_parent">
 
-                    <!-- Empty State -->
-                    <LinearLayout
-                        android:id="@+id/emptyState"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="vertical"
-                        android:gravity="center"
-                        android:padding="32dp"
-                        android:visibility="gone"
-                        tools:visibility="visible">
+                        <!-- Interview List (scrolls independently) -->
+                        <androidx.recyclerview.widget.RecyclerView
+                            android:id="@+id/recyclerViewInterviews"
+                            android:layout_width="match_parent"
+                            android:layout_height="match_parent"
+                            android:clipToPadding="false"
+                            android:paddingBottom="80dp" />
 
-                        <ImageView
-                            android:layout_width="64dp"
-                            android:layout_height="64dp"
-                            android:src="@drawable/ic_calendar_empty"
-                            android:importantForAccessibility="no"
-                            app:tint="?attr/colorOnSurfaceVariant" />
-
-                        <TextView
-                            android:id="@+id/textEmptyTitle"
-                            android:layout_width="wrap_content"
+                        <!-- Empty State -->
+                        <LinearLayout
+                            android:id="@+id/emptyState"
+                            android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_marginTop="16dp"
-                            android:text="No Interviews Scheduled"
-                            android:textAppearance="?attr/textAppearanceTitleMedium"
-                            android:textColor="?attr/colorOnSurface" />
+                            android:orientation="vertical"
+                            android:gravity="center"
+                            android:padding="32dp"
+                            android:visibility="gone"
+                            tools:visibility="visible">
 
-                        <TextView
-                            android:id="@+id/textEmptyDescription"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginTop="8dp"
-                            android:text="Select a date to add an interview"
-                            android:textAppearance="?attr/textAppearanceBodyMedium"
-                            android:textColor="?attr/colorOnSurfaceVariant" />
+                            <ImageView
+                                android:layout_width="64dp"
+                                android:layout_height="64dp"
+                                android:src="@drawable/ic_calendar_empty"
+                                android:importantForAccessibility="no"
+                                app:tint="?attr/colorOnSurfaceVariant" />
 
-                    </LinearLayout>
+                            <TextView
+                                android:id="@+id/textEmptyTitle"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="16dp"
+                                android:text="No Interviews Scheduled"
+                                android:textAppearance="?attr/textAppearanceTitleMedium"
+                                android:textColor="?attr/colorOnSurface" />
 
-                </FrameLayout>
+                            <TextView
+                                android:id="@+id/textEmptyDescription"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="8dp"
+                                android:text="Select a date to add an interview"
+                                android:textAppearance="?attr/textAppearanceBodyMedium"
+                                android:textColor="?attr/colorOnSurfaceVariant" />
+
+                        </LinearLayout>
+
+                    </FrameLayout>
+
+                </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
             </LinearLayout>
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -80,59 +80,66 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <!-- Scrollable List Area -->
-        <FrameLayout
+        <!-- Scrollable List Area with Pull-to-Refresh -->
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/swipeRefreshLayout"
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1">
 
-            <!-- Interview List (scrolls independently) -->
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/recyclerViewInterviews"
+            <FrameLayout
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:clipToPadding="false"
-                android:paddingBottom="80dp" />
+                android:layout_height="match_parent">
 
-            <!-- Empty State -->
-            <LinearLayout
-                android:id="@+id/emptyState"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:gravity="center"
-                android:padding="32dp"
-                android:visibility="gone"
-                tools:visibility="visible">
+                <!-- Interview List (scrolls independently) -->
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/recyclerViewInterviews"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:clipToPadding="false"
+                    android:paddingBottom="80dp" />
 
-                <ImageView
-                    android:layout_width="64dp"
-                    android:layout_height="64dp"
-                    android:src="@drawable/ic_calendar_empty"
-                    android:importantForAccessibility="no"
-                    app:tint="?attr/colorOnSurfaceVariant" />
-
-                <TextView
-                    android:id="@+id/textEmptyTitle"
-                    android:layout_width="wrap_content"
+                <!-- Empty State -->
+                <LinearLayout
+                    android:id="@+id/emptyState"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="16dp"
-                    android:text="No Interviews Scheduled"
-                    android:textAppearance="?attr/textAppearanceTitleMedium"
-                    android:textColor="?attr/colorOnSurface" />
+                    android:orientation="vertical"
+                    android:gravity="center"
+                    android:padding="32dp"
+                    android:visibility="gone"
+                    tools:visibility="visible">
 
-                <TextView
-                    android:id="@+id/textEmptyDescription"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:text="Select a date to add an interview"
-                    android:textAppearance="?attr/textAppearanceBodyMedium"
-                    android:textColor="?attr/colorOnSurfaceVariant" />
+                    <ImageView
+                        android:layout_width="64dp"
+                        android:layout_height="64dp"
+                        android:src="@drawable/ic_calendar_empty"
+                        android:importantForAccessibility="no"
+                        app:tint="?attr/colorOnSurfaceVariant" />
 
-            </LinearLayout>
+                    <TextView
+                        android:id="@+id/textEmptyTitle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="16dp"
+                        android:text="No Interviews Scheduled"
+                        android:textAppearance="?attr/textAppearanceTitleMedium"
+                        android:textColor="?attr/colorOnSurface" />
 
-        </FrameLayout>
+                    <TextView
+                        android:id="@+id/textEmptyDescription"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:text="Select a date to add an interview"
+                        android:textAppearance="?attr/textAppearanceBodyMedium"
+                        android:textColor="?attr/colorOnSurfaceVariant" />
+
+                </LinearLayout>
+
+            </FrameLayout>
+
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
     </LinearLayout>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -12,7 +12,7 @@
     <color name="outcome_scheduled">#FF2196F3</color>
     <color name="outcome_passed">#FF4CAF50</color>
     <color name="outcome_rejected">#FFF44336</color>
-    <color name="outcome_awaiting">#FFFFEB3B</color>
+    <color name="outcome_awaiting">#FF000000</color>
     <color name="outcome_offer_received">#FF9C27B0</color>
     <color name="outcome_offer_accepted">#FF4CAF50</color>
     <color name="outcome_offer_declined">#FFFF9800</color>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ clerkUI = "0.1.2"
 retrofit = "2.11.0"
 okhttp = "4.12.0"
 gson = "2.11.0"
+swiperefresh = "1.2.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -50,6 +51,7 @@ retrofit-gson = { group = "com.squareup.retrofit2", name = "converter-gson", ver
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
+androidx-swiperefresh = { group = "androidx.swiperefreshlayout", name = "swiperefreshlayout", version.ref = "swiperefresh" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Add SwipeRefreshLayout around the main list and wire up a pull-to-refresh
handler that triggers a full sync. Initialize swipeRefreshLayout in
MainActivity, add setOnRefreshListener that calls performPullToRefreshSync(),
and implement performPullToRefreshSync() to:

- check current Clerk user/session and fetch auth token
- set APIService auth token when available
- call syncService.syncAll()
- show Snackbar messages for success, missing auth, or failures
- always stop the refreshing spinner in finally

Also:
- add androidx swiperefresh dependency in libs.versions.toml
- declare swipeRefreshLayout view ID in the sw600dp activity_main layout
- remove unused imports in MainActivity and update colors.xml to change
  outcome_awaiting color value

This enables manual user-initiated syncs via pull-to-refresh and improves
feedback on sync status.