### PR TITLE
refactor(ui): remove unused clientCompany field and handling

### DIFF
--- a/app/src/main/java/tools/interviews/android/AddInterviewActivity.kt
+++ b/app/src/main/java/tools/interviews/android/AddInterviewActivity.kt
@@ -60,7 +60,6 @@ class AddInterviewActivity : AppCompatActivity() {
     private lateinit var buttonSave: MaterialButton
     private lateinit var dropdownStage: AutoCompleteTextView
     private lateinit var editCompanyName: AutoCompleteTextView
-    private lateinit var editClientCompany: TextInputEditText
     private lateinit var editJobTitle: TextInputEditText
     private lateinit var editJobListing: TextInputEditText
     private lateinit var sectionInterviewDetails: LinearLayout
@@ -162,9 +161,6 @@ class AddInterviewActivity : AppCompatActivity() {
             // Pre-fill all metadata from previous interview
             intent.getStringExtra(EXTRA_COMPANY_NAME)?.let {
                 editCompanyName.setText(it)
-            }
-            intent.getStringExtra(EXTRA_CLIENT_COMPANY)?.let {
-                editClientCompany.setText(it)
             }
             intent.getStringExtra(EXTRA_JOB_TITLE)?.let {
                 editJobTitle.setText(it)

--- a/app/src/main/java/tools/interviews/android/EditInterviewActivity.kt
+++ b/app/src/main/java/tools/interviews/android/EditInterviewActivity.kt
@@ -36,7 +36,6 @@ class EditInterviewActivity : AppCompatActivity() {
     private lateinit var buttonSave: MaterialButton
     private lateinit var dropdownStage: AutoCompleteTextView
     private lateinit var editCompanyName: AutoCompleteTextView
-    private lateinit var editClientCompany: TextInputEditText
     private lateinit var editJobTitle: TextInputEditText
     private lateinit var editJobListing: TextInputEditText
     private lateinit var sectionInterviewDetails: LinearLayout
@@ -142,7 +141,6 @@ class EditInterviewActivity : AppCompatActivity() {
         applicationDate = interview.applicationDate
 
         editCompanyName.setText(interview.companyName)
-        editClientCompany.setText(interview.clientCompany ?: "")
         editJobTitle.setText(interview.jobTitle)
         editJobListing.setText(interview.jobListing ?: "")
 
@@ -364,7 +362,6 @@ class EditInterviewActivity : AppCompatActivity() {
             id = interviewId,
             jobTitle = editJobTitle.text.toString().trim(),
             companyName = editCompanyName.text.toString().trim(),
-            clientCompany = editClientCompany.text?.toString()?.trim()?.takeIf { it.isNotEmpty() },
             stage = selectedStage,
             method = selectedMethod,
             outcome = selectedOutcome,


### PR DESCRIPTION
Remove the now-unused editClientCompany TextInputEditText from both
AddInterviewActivity and EditInterviewActivity classes. Eliminate the
associated setText and request-reading logic where clientCompany was
previously populated from intents or the Interview model.

This simplifies the UI code and model mapping by dropping a deprecated
client company input that is no longer captured in the form. It
prevents unnecessary nullable checks and trimmed-string handling when
building Interview objects.