### PR TITLE
chore: bump app versionName to 1.0.5

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,7 +30,7 @@ android {
         minSdk = 26
         targetSdk = 36
         versionCode = project.findProperty("versionCode")?.toString()?.toIntOrNull() ?: 1
-        versionName = "1.0.4"
+        versionName = "1.0.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Update Android app versionName from 1.0.4 to 1.0.5 in build.gradle.kts.
This increments the published version so users and stores receive the
latest build and ensures versionCode/versionName remain consistent
for release management.