### PR TITLE
chore: bump app versionName to 1.0.8

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,7 +30,7 @@ android {
         minSdk = 26
         targetSdk = 36
         versionCode = project.findProperty("versionCode")?.toString()?.toIntOrNull() ?: 1
-        versionName = "1.0.7"
+        versionName = "1.0.8"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
Update app/build.gradle.kts to change the versionName from
"1.0.7" to "1.0.8". This increments the published app version so
builds and releases reflect the latest changes and avoid
version conflicts when deploying updates.